### PR TITLE
Added ability to archive taxonomy sections

### DIFF
--- a/app/controllers/api/taxonomy_controller.rb
+++ b/app/controllers/api/taxonomy_controller.rb
@@ -2,7 +2,7 @@ require 'will_paginate/array'
 
 class Api::TaxonomyController < Api::BaseController
   def index
-    nodes = Taxonomy.nodes.paginate(
+    nodes = Taxonomy.nodes(include_archived: true).paginate(
       page: params[:page],
       per_page: params[:limit]
     )

--- a/spec/config/taxonomy.yml
+++ b/spec/config/taxonomy.yml
@@ -12,6 +12,9 @@
     - id: 5
       new_id: 3
       name: Merged
+    - id: 10
+      name: Archived
+      archived: true
 - id: 6
   name: Sports
 - id: 7

--- a/spec/requests/api/taxonomy_spec.rb
+++ b/spec/requests/api/taxonomy_spec.rb
@@ -6,9 +6,13 @@ describe "/sections/*" do
     let(:nodes) { ActiveSupport::JSON.decode(response.body) }
     subject { nodes }
 
-    it { should have(11).nodes }
+    it { should have(12).nodes }
     it "should contain blog nodes" do
       nodes.map { |node| node['name'] }.should include('Pokedex')
+    end
+
+    it "should contain archived nodes" do
+      nodes.map { |node| node['name'] }.should include('Archived')
     end
 
     describe "taxonomy node" do


### PR DESCRIPTION
This adds the ability to "archive" taxonomies, so that they are not as prominent on the site, i.e. they don't show up on their parent's page headers. However, they are kept around so that older articles can still belong to a section.

When archived, the taxonomies will appear to Camayak (/sections under API), and in the sitemap.
